### PR TITLE
feat: Implement Get User and Get All Users endpoints

### DIFF
--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+import { NotFoundException } from '@nestjs/common';
+import { CanActivate } from '@nestjs/common';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+  let service: UsersService;
+
+  const mockUsersService = {
+    findOneById: jest.fn(),
+    findAll: jest.fn(),
+    signupUser: jest.fn(), // Added to mock all service methods used by controller
+  };
+
+  // Mock JwtAuthGuard
+  const mockJwtAuthGuard: CanActivate = { canActivate: jest.fn(() => true) };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    })
+    .overrideGuard(JwtAuthGuard)
+    .useValue(mockJwtAuthGuard)
+    .compile();
+
+    controller = module.get<UsersController>(UsersController);
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getUserById', () => {
+    it('should return a user when found', async () => {
+      const userId = 'some-uuid';
+      const mockUser = { id: userId, name: 'Test User', phone: '1234567890' }; // Password already excluded by service
+      mockUsersService.findOneById.mockResolvedValue(mockUser);
+
+      const result = await controller.getUserById(userId);
+      expect(service.findOneById).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw NotFoundException when user not found', async () => {
+      const userId = 'non-existent-uuid';
+      mockUsersService.findOneById.mockRejectedValue(new NotFoundException('User not found'));
+
+      await expect(controller.getUserById(userId)).rejects.toThrow(NotFoundException);
+      expect(service.findOneById).toHaveBeenCalledWith(userId);
+    });
+  });
+
+  describe('getAllUsers', () => {
+    it('should return an array of users', async () => {
+      const mockUsers = [
+        { id: 'uuid1', name: 'User One', phone: '111' },
+        { id: 'uuid2', name: 'User Two', phone: '222' },
+      ]; // Passwords already excluded by service
+      mockUsersService.findAll.mockResolvedValue(mockUsers);
+
+      const result = await controller.getAllUsers();
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(mockUsers);
+    });
+
+    it('should return an empty array if no users are found', async () => {
+      mockUsersService.findAll.mockResolvedValue([]);
+
+      const result = await controller.getAllUsers();
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param, NotFoundException, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UserSignupDto } from './dto/users.signup.dto';
+import { JwtAuthGuard } from 'src/auth/jwt.guard';
 
 @Controller('users')
 export class UsersController {
@@ -9,5 +10,17 @@ export class UsersController {
   @Post('signup')
   async createUser(@Body() userSignupDto: UserSignupDto) {
     return this.userService.signupUser(userSignupDto);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard)
+  async getUserById(@Param('id') id: string) {
+    return this.userService.findOneById(id);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  async getAllUsers() {
+    return this.userService.findAll();
   }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UsersEntity } from './users.entity';
+import { JwtService } from '@nestjs/jwt';
+import { NotFoundException } from '@nestjs/common';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let userRepository;
+
+  const mockUserRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockJwtService = {
+    sign: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(UsersEntity),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: JwtService,
+          useValue: mockJwtService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    userRepository = module.get(getRepositoryToken(UsersEntity));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findOneById', () => {
+    it('should return a user if found and exclude password', async () => {
+      const userId = 'some-uuid';
+      const mockUser = { id: userId, name: 'Test User', phone: '1234567890', password: 'hashedPassword' };
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+
+      const result = await service.findOneById(userId);
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+      expect(result).toEqual({ id: userId, name: 'Test User', phone: '1234567890' });
+      expect(result.password).toBeUndefined();
+    });
+
+    it('should throw NotFoundException if user not found', async () => {
+      const userId = 'non-existent-uuid';
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOneById(userId)).rejects.toThrow(NotFoundException);
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of users and exclude passwords', async () => {
+      const mockUsers = [
+        { id: 'uuid1', name: 'User One', phone: '111', password: 'p1' },
+        { id: 'uuid2', name: 'User Two', phone: '222', password: 'p2' },
+      ];
+      mockUserRepository.find.mockResolvedValue(mockUsers);
+
+      const result = await service.findAll();
+      expect(userRepository.find).toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'uuid1', name: 'User One', phone: '111' },
+        { id: 'uuid2', name: 'User Two', phone: '222' },
+      ]);
+      result.forEach(user => expect(user.password).toBeUndefined());
+    });
+
+    it('should return an empty array if no users found', async () => {
+      mockUserRepository.find.mockResolvedValue([]);
+      const result = await service.findAll();
+      expect(userRepository.find).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UsersEntity } from './users.entity';
 import { Repository } from 'typeorm';
@@ -49,5 +49,22 @@ export class UsersService {
 
   async findByPhone(phone: string) {
     return await this.userRepo.findOne({ where: { phone: phone } });
+  }
+
+  async findOneById(id: string) {
+    const user = await this.userRepo.findOne({ where: { id: id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    const { password, ...userWithoutPassword } = user;
+    return userWithoutPassword;
+  }
+
+  async findAll() {
+    const users = await this.userRepo.find();
+    return users.map((user) => {
+      const { password, ...userWithoutPassword } = user;
+      return userWithoutPassword;
+    });
   }
 }


### PR DESCRIPTION
Adds two new GET endpoints to the Users module:
- GET /users/:id : Retrieves a single user by their ID.
- GET /users : Retrieves all users.

Both endpoints are protected by JWT authentication.

The UsersService has been updated with `findOneById` and `findAll` methods. These methods ensure that user passwords are not exposed through the API. Appropriate error handling (e.g., NotFoundException for non-existent users) has been implemented.

Unit tests have been added for both the UsersService and UsersController to cover the new functionality, including successful data retrieval, error handling, and password exclusion.